### PR TITLE
added mailhog container

### DIFF
--- a/development/.env
+++ b/development/.env
@@ -4,3 +4,4 @@ DB_NAME=wordpress
 
 #here you can switch between mysql/mariadb
 DATABASE=mariadb
+HOSTNAME=firsthost.test

--- a/development/README.md
+++ b/development/README.md
@@ -33,3 +33,6 @@ If you change the value of the `DATABASE` variable at any time during developmen
     - `docker volume rm <volume-id>`
 3. rebuild the docker image
     - `docker-compose up --build -d`
+
+## Adding hostfile
+ To make use of the container mailhog you need to create a hosts file entry you can do this by editing `/etc/host` make sure that this record matches the variable in `.env`called HOSTNAME

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -3,9 +3,12 @@ version: "3"
 services:
   wp:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
+    extra_hosts:
+      - "${HOSTNAME}:${IP}"
     container_name: cc-base-wp
     ports:
       - ${IP}:80:80 # change ip if required
+    
     volumes:
       - ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html # Full wordpress project
@@ -18,10 +21,8 @@ services:
       WORDPRESS_DB_PASSWORD: "${DB_ROOT_PASSWORD}"
     depends_on:
       - db
-
-    links:
-      - db
-
+    networks:
+      - backend
   wpcli:
     image: wordpress:cli
     container_name: cc-base-wp-cli
@@ -36,9 +37,8 @@ services:
     depends_on:
       - db
       - wp
-    links:
-      - db:db
-
+    networks:
+      - backend
   pma:
     image: phpmyadmin/phpmyadmin
     container_name: cc-base-phpmyadmin
@@ -49,9 +49,8 @@ services:
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
     ports:
       - ${IP}:8080:80
-    links:
-      - db:db
-
+    networks:
+      - backend
   db:
     build:
       context: ./bin/${DATABASE} #change db if required in .env file
@@ -65,6 +64,21 @@ services:
       MYSQL_DATABASE: "${DB_NAME}"
       MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
+    networks:
+      - backend
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    extra_hosts:
+      - "${HOSTNAME}:${IP}"
+    restart: always
+    logging:
+      driver: 'none' #this is required since mailhog is very chatty to the log files 
+    ports:
+      - 1025:1025 #api port
+      - 8025:8025 #webinterface port
+    
+    
 
   composer:
     image: composer/composer
@@ -79,3 +93,6 @@ services:
 
 volumes:
   db_data:
+
+networks:
+  backend:


### PR DESCRIPTION

## Fixes
added the mailhog container
Fixes #109  by @alainseys 

## Description
Added a new variable hostname so you can test with a virtual domain.
Localy the developer  needs to set /etc/hosts to the same so docker knows how to bind this.

Updated the README.md with this information.

The mailhog enviroment listens on the port 8025 for the gui

## Technical details
create a new entry in your /etc/hosts that matches the variable HOSTNAME eg:

wordpress.test 127.0.0.1

then your variable should we wordpress.test
## Tests
i have test this localy with telnet the mails i have send showed up in mailhog , optionaly you can fill out wp-config.php with the smtp settings here you should read out the variable i have created (this was the main reason i have created this one)

## Checklist

- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
