### PR TITLE
Change default Gutenberg colors to CC brand guidelines

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -353,7 +353,7 @@ add_theme_support( 'editor-color-palette', $cc_colors);
  */
 add_action( 'wp_head', function() {
     $palette = get_theme_support( 'editor-color-palette' );
-	if( !$palette ) { return; } // If our color
+	if( !$palette ) { return; } // If our color pallete has not been define don't run this function.
 		
 	// format styles
 	$styles = ":root .has-background { background-color: var(--bgColor); }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/106 by @brylie 

## Description
I added the CC colors (brand, soft brand, neutral and binary) to this submodule. This PR applies well to the editor panel. However, the resulting CSS generated is not in line with how classes are generated in vocabulary.

## Screenshots
![image](https://user-images.githubusercontent.com/40151808/138032300-cbb033d5-6292-40df-9825-88a0abeadb26.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
