### PR TITLE
Wordpress Blocks Override Default Font Sizes with Figma Guided font sizes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -47,10 +47,6 @@ add_image_size( 'landscape-small', 550, 300, true );
 add_image_size( 'landscape-medium', 740, 416, true );
 add_image_size( 'landscape-featured', 1000, 500, true );
 
-//Media Upload size
-@ini_set( 'upload_max_size' , '64M' );
-@ini_set( 'post_max_size', '64M');
-@ini_set( 'max_execution_time', '300' );
 
 /**
 *  THEME SIDEBARS

--- a/functions.php
+++ b/functions.php
@@ -235,14 +235,14 @@ class Site {
 	{
 		$cc_sizes = array(
 			array(
-				'name' => esc_attr__( 'Caption', 'ccTypography' ),
+				'name' => esc_attr__( 'Small', 'ccTypography' ),
 				'size' => 13,
-				'slug' => 'caption'
+				'slug' => 'small'
 			),
 			array(
-				'name' => esc_attr__( 'Body Normal', 'ccTypography' ),
+				'name' => esc_attr__( 'Normal', 'ccTypography' ),
 				'size' => 16,
-				'slug' => 'body-normal'
+				'slug' => 'normal'
 			),
 			array(
 				'name' => esc_attr__( 'Body Big', 'ccTypography' ),
@@ -250,39 +250,24 @@ class Site {
 				'slug' => 'body-big'
 			),
 			array(
+				'name' => esc_attr__( 'Medium', 'ccTypography' ),
+				'size' => 20,
+				'slug' => 'medium'
+			),
+			array(
 				'name' => esc_attr__( 'Body Bigger', 'ccTypography' ),
 				'size' => 23,
 				'slug' => 'body-bigger'
 			),
 			array(
-				'name' => esc_attr__( 'H6', 'ccTypography' ),
-				'size' => 18,
-				'slug' => 'h6'
-			),
-			array(
-				'name' => esc_attr__( 'H5', 'ccTypography' ),
-				'size' => 20,
-				'slug' => 'h5'
-			),
-			array(
-				'name' => esc_attr__( 'H4', 'ccTypography' ),
-				'size' => 23,
-				'slug' => 'h4'
-			),
-			array(
-				'name' => esc_attr__( 'H3', 'ccTypography' ),
-				'size' => 28,
-				'slug' => 'h3'
-			),
-			array(
-				'name' => esc_attr__( 'H2', 'ccTypography' ),
+				'name' => esc_attr__( 'Large', 'ccTypography' ),
 				'size' => 36,
-				'slug' => 'h2'
+				'slug' => 'Large'
 			),
 			array(
-				'name' => esc_attr__( 'H1', 'ccTypography' ),
+				'name' => esc_attr__( 'Huge', 'ccTypography' ),
 				'size' => 57,
-				'slug' => 'h1'
+				'slug' => 'huge'
 			),
 			array(
 				'name' => esc_attr__( 'Value', 'ccTypography' ),

--- a/functions.php
+++ b/functions.php
@@ -47,6 +47,11 @@ add_image_size( 'landscape-small', 550, 300, true );
 add_image_size( 'landscape-medium', 740, 416, true );
 add_image_size( 'landscape-featured', 1000, 500, true );
 
+//Media Upload size
+@ini_set( 'upload_max_size' , '64M' );
+@ini_set( 'post_max_size', '64M');
+@ini_set( 'max_execution_time', '300' );
+
 /**
 *  THEME SIDEBARS
 *  Default sidebars availables
@@ -225,6 +230,72 @@ class Site {
 		);
 		wp_localize_script( 'cc_base_script', 'Ajax', $ajax_data );
 	}
+
+	/**
+	 * This function sets the font sizes
+	 * as given on the Figma guidelines.
+	 */
+	function cc_typography()
+	{
+		$cc_sizes = array(
+			array(
+				'name' => esc_attr__( 'Caption', 'ccTypography' ),
+				'size' => 13,
+				'slug' => 'caption'
+			),
+			array(
+				'name' => esc_attr__( 'Body Normal', 'ccTypography' ),
+				'size' => 16,
+				'slug' => 'body-normal'
+			),
+			array(
+				'name' => esc_attr__( 'Body Big', 'ccTypography' ),
+				'size' => 18,
+				'slug' => 'body-big'
+			),
+			array(
+				'name' => esc_attr__( 'Body Bigger', 'ccTypography' ),
+				'size' => 23,
+				'slug' => 'body-bigger'
+			),
+			array(
+				'name' => esc_attr__( 'H6', 'ccTypography' ),
+				'size' => 18,
+				'slug' => 'h6'
+			),
+			array(
+				'name' => esc_attr__( 'H5', 'ccTypography' ),
+				'size' => 20,
+				'slug' => 'h5'
+			),
+			array(
+				'name' => esc_attr__( 'H4', 'ccTypography' ),
+				'size' => 23,
+				'slug' => 'h4'
+			),
+			array(
+				'name' => esc_attr__( 'H3', 'ccTypography' ),
+				'size' => 28,
+				'slug' => 'h3'
+			),
+			array(
+				'name' => esc_attr__( 'H2', 'ccTypography' ),
+				'size' => 36,
+				'slug' => 'h2'
+			),
+			array(
+				'name' => esc_attr__( 'H1', 'ccTypography' ),
+				'size' => 57,
+				'slug' => 'h1'
+			),
+			array(
+				'name' => esc_attr__( 'Value', 'ccTypography' ),
+				'size' => 70,
+				'slug' => 'value'
+			),
+		);
+		add_theme_support( 'editor-font-sizes', $cc_sizes);	
+	}
 }
 
 /**
@@ -232,6 +303,11 @@ class Site {
  * */
 
 $_s = Site::get_instance();
+
+//This action overrriveds the default wordpress sizes
+add_action( 'after_setup_theme', function() {
+	Site::cc_typography();
+});
 
 /**
  * This line disables the default color picker so users are constrained just to the
@@ -359,7 +435,7 @@ add_action( 'wp_head', function() {
 		
 	// format styles
 	$styles = ":root .has-background { background-color: var(--bgColor); }
-	:root .has-text-color { color: var(--textColor); } ";
+	:root .has-text-color { color: var(--textColor); } :root .has-inline-color { color: var(--textColor); }";
 	foreach( $palette[0] as $name => $value ) {
 		$slug = $value['slug'];
 		$color = $value['color'];

--- a/style.css
+++ b/style.css
@@ -42,22 +42,22 @@ This theme, like WordPress, is licensed under the GPL.
 .has-body-bigger-font-size {
 	font-size: 1.43rem;
 }
-.has-h6-font-size {
+.has-h-6-font-size {
 	font-size: 1.15rem;
 }
-.has-h5-font-size {
+.has-h-5-font-size {
 	font-size: 1.25rem;
 }
-.has-h4-font-size {
+.has-h-4-font-size {
 	font-size: 1.43rem;
 }
-.has-h3-font-size {
+.has-h-3-font-size {
 	font-size: 1.75rem;
 }
-.has-h2-font-size {
+.has-h-2-font-size {
 	font-size: 2.25rem;
 }
-.has-h1-font-size {
+.has-h-1-font-size {
 	font-size: 3.56rem;
 }
 .has-value-font-size {

--- a/style.css
+++ b/style.css
@@ -29,3 +29,37 @@ This theme, like WordPress, is licensed under the GPL.
     /* add overflow rule */
     overflow: hidden;
 }
+/*override wp font size css*/
+.has-caption-font-size {
+    font-size: 0.8rem;
+}
+.has-body-normal-font-size {
+	font-size: 1rem;
+}
+.has-body-big-font-size {
+	font-size: 1.12rem;
+}
+.has-body-bigger-font-size {
+	font-size: 1.43rem;
+}
+.has-h6-font-size {
+	font-size: 1.15rem;
+}
+.has-h5-font-size {
+	font-size: 1.25rem;
+}
+.has-h4-font-size {
+	font-size: 1.43rem;
+}
+.has-h3-font-size {
+	font-size: 1.75rem;
+}
+.has-h2-font-size {
+	font-size: 2.25rem;
+}
+.has-h1-font-size {
+	font-size: 3.56rem;
+}
+.has-value-font-size {
+	font-size: 4.37rem;
+}

--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ This theme, like WordPress, is licensed under the GPL.
     overflow: hidden;
 }
 /*override wp font size css*/
-.has-caption-font-size {
+.has-small-font-size {
     font-size: 0.8rem;
 }
 .has-body-normal-font-size {
@@ -42,22 +42,13 @@ This theme, like WordPress, is licensed under the GPL.
 .has-body-bigger-font-size {
 	font-size: 1.43rem;
 }
-.has-h-6-font-size {
-	font-size: 1.15rem;
-}
-.has-h-5-font-size {
+.has-medium-font-size {
 	font-size: 1.25rem;
 }
-.has-h-4-font-size {
-	font-size: 1.43rem;
-}
-.has-h-3-font-size {
-	font-size: 1.75rem;
-}
-.has-h-2-font-size {
+.has-large-font-size {
 	font-size: 2.25rem;
 }
-.has-h-1-font-size {
+.has-huge-font-size {
 	font-size: 3.56rem;
 }
 .has-value-font-size {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/110 by @brylie 

## Description
I used the Figma guides along with how the typography font sizes are defined in Vocabulary to work on this. 
In the `functions.php` file I used the font sizes given on Figma (which have `px` as units) given that the `functions.php` file accepts its values in `px`.
For the CSS rendered on the frontend, I used the `rem` units as is used in the Vocabulary package.

I didn't disable the possibility of manually entering a custom font size but if this is required I can quickly include it in another commit.
## Screenshots
![image](https://user-images.githubusercontent.com/40151808/139826278-5478e0cc-d782-45da-8dd1-022098254c81.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
