### PR TITLE
Add support for Inline colors to Gutenberg editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -211,6 +211,8 @@ class Site {
 			wp_enqueue_media();
 			wp_enqueue_script( 'script-admin', THEME_JS . '/admin_scripts.js', array( 'jquery' ), self::theme_ver );
 		}
+		// Add custom stylesheet for admins
+		wp_enqueue_style( 'cc_custom_style', CUSTOM_CSS . '/style.css', self::theme_ver );
 	}
 
 	function enqueue_scripts() {
@@ -224,38 +226,6 @@ class Site {
 			'url' => admin_url( 'admin-ajax.php' ),
 		);
 		wp_localize_script( 'cc_base_script', 'Ajax', $ajax_data );
-	}
-
-	/**
-	 * Given than WordPress generates css class names following the convention:
-	 * .has-{slug}-color and .has-{slug}-background-color. 
-	 * When rendering pages on the frontend, these are the css classes applied to the different HTML elements
-	 * which is different from how the Vocabulary package generates it's CSS classes:
-	 * .has-color-{slug} and .has-backgound-{slug}. 
-	 * This function below takes the colors we have added to 
-	 * the color palette of wordpress and generates WordPress compatible class names. 
-	 * The styles generated are then added to the HTML pages as Internal CSS styles. 
-	 * We do this by using the Wordpress action (wp_head) which lets us run this function when the head is called.
-	 * @var editor-color-palette
-	 */
-	function custom_css()
-	{
-		$palette = get_theme_support( 'editor-color-palette' );
-		if( !$palette ) { return; } // If our color palette has not been define don't run this function.
-			
-		// format styles
-		$styles = ":root .has-background { background-color: var(--bgColor); }
-		:root .has-text-color { color: var(--textColor); } :root .has-inline-color { color: var(--textColor); } ";
-		foreach( $palette[0] as $name => $value ) {
-			$slug = $value['slug'];
-			$color = $value['color'];
-		
-			$styles .= ".has-{$slug}-background-color { --bgColor: {$color}; } ";
-			$styles .= ".has-{$slug}-color { --textColor: {$color}; } ";
-		}
-		
-		// add styles as internal css to the head of the rendered HTML page.
-		return $styles;
 	}
 }
 
@@ -372,13 +342,3 @@ $cc_colors = array(
 
 // This line below adds the colors defined above into the color pallete of WordPress
 add_theme_support( 'editor-color-palette', $cc_colors);
-
-// Action to add CC css colors to Frontend
-add_action("cc_theme_before_header" , function() {
-    echo "<style>".Site::custom_css()."</style>";
-});
-
-// Action to add CC inline color css classes to gutenberg editor
-add_action("admin_head" , function() {
-    echo "<style>".Site::custom_css()."</style>";
-});

--- a/functions.php
+++ b/functions.php
@@ -240,22 +240,22 @@ class Site {
 	 */
 	function custom_css()
 	{
-	   $palette = get_theme_support( 'editor-color-palette' );
-	   if( !$palette ) { return; } // If our color palette has not been define don't run this function.
-		   
-	   // format styles
-	   $styles = ":root .has-background { background-color: var(--bgColor); }
-	   :root .has-text-color { color: var(--textColor); } :root .has-inline-color { color: var(--textColor); } ";
-	   foreach( $palette[0] as $name => $value ) {
-		   $slug = $value['slug'];
-		   $color = $value['color'];
-	   
-		   $styles .= ".has-{$slug}-background-color { --bgColor: {$color}; } ";
-		   $styles .= ".has-{$slug}-color { --textColor: {$color}; } ";
-	   }
-	   
-	   // add styles as internal css to the head of the rendered HTML page.
-	   return $styles;
+		$palette = get_theme_support( 'editor-color-palette' );
+		if( !$palette ) { return; } // If our color palette has not been define don't run this function.
+			
+		// format styles
+		$styles = ":root .has-background { background-color: var(--bgColor); }
+		:root .has-text-color { color: var(--textColor); } :root .has-inline-color { color: var(--textColor); } ";
+		foreach( $palette[0] as $name => $value ) {
+			$slug = $value['slug'];
+			$color = $value['color'];
+		
+			$styles .= ".has-{$slug}-background-color { --bgColor: {$color}; } ";
+			$styles .= ".has-{$slug}-color { --textColor: {$color}; } ";
+		}
+		
+		// add styles as internal css to the head of the rendered HTML page.
+		return $styles;
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -225,6 +225,38 @@ class Site {
 		);
 		wp_localize_script( 'cc_base_script', 'Ajax', $ajax_data );
 	}
+
+	/**
+	 * Given than WordPress generates css class names following the convention:
+	 * .has-{slug}-color and .has-{slug}-background-color. 
+	 * When rendering pages on the frontend, these are the css classes applied to the different HTML elements
+	 * which is different from how the Vocabulary package generates it's CSS classes:
+	 * .has-color-{slug} and .has-backgound-{slug}. 
+	 * This function below takes the colors we have added to 
+	 * the color pallete of wordpress and generates WordPress compatible class names. 
+	 * The styles generated are then added to the HTML pages as Internal CSS styles. 
+	 * We do this by using the Wordpress action (wp_head) which lets us run this function when the head is called.
+	 * @var editor-color-pallete
+	 */
+	function custom_css()
+	{
+	   $palette = get_theme_support( 'editor-color-palette' );
+	   if( !$palette ) { return; } // If our color pallete has not been define don't run this function.
+		   
+	   // format styles
+	   $styles = ":root .has-background { background-color: var(--bgColor); }
+	   :root .has-text-color { color: var(--textColor); } :root .has-inline-color { color: var(--textColor); } ";
+	   foreach( $palette[0] as $name => $value ) {
+		   $slug = $value['slug'];
+		   $color = $value['color'];
+	   
+		   $styles .= ".has-{$slug}-background-color { --bgColor: {$color}; } ";
+		   $styles .= ".has-{$slug}-color { --textColor: {$color}; } ";
+	   }
+	   
+	   // add styles as internal css to the head of the rendered HTML page.
+	   return $styles;
+	}
 }
 
 /**
@@ -341,34 +373,12 @@ $cc_colors = array(
 // This line below adds the colors defined above into the color pallete of WordPress
 add_theme_support( 'editor-color-palette', $cc_colors);
 
-
-/**
- * Given than WordPress generates css class names following the convention:
- * .has-{slug}-color and .has-{slug}-background-color. 
- * When rendering pages on the frontend, these are the css classes applied to the different HTML elements
- * which is different from how the Vocabulary package generates it's CSS classes:
- * .has-color-{slug} and .has-backgound-{slug}. 
- * This function below takes the colors we have added to 
- * the color pallete of wordpress and generates WordPress compatible class names. 
- * The styles generated are then added to the HTML pages as Internal CSS styles. 
- * We do this by using the Wordpress action (wp_head) which lets us run this function when the head is called.
- */
-add_action( 'wp_head', function() {
-    $palette = get_theme_support( 'editor-color-palette' );
-	if( !$palette ) { return; } // If our color pallete has not been define don't run this function.
-		
-	// format styles
-	$styles = ":root .has-background { background-color: var(--bgColor); }
-	:root .has-text-color { color: var(--textColor); } ";
-	foreach( $palette[0] as $name => $value ) {
-		$slug = $value['slug'];
-		$color = $value['color'];
-	
-		$styles .= ".has-{$slug}-background-color { --bgColor: {$color}; } ";
-		$styles .= ".has-{$slug}-color { --textColor: {$color}; } ";
-	}
-	
-	// add styles as internal css to the head of the rendered HTML page.
-	echo "<style> $styles </style>";
+// Action to add CC css colors to Frontend
+add_action("cc_theme_before_header" , function() {
+    echo "<style>".Site::custom_css()."</style>";
 });
 
+// Action to add CC inline color css classes to gutenberg editor
+add_action("enqueue_block_editor_assets" , function() {
+    echo "<style>".Site::custom_css()."</style>";
+});

--- a/functions.php
+++ b/functions.php
@@ -233,15 +233,15 @@ class Site {
 	 * which is different from how the Vocabulary package generates it's CSS classes:
 	 * .has-color-{slug} and .has-backgound-{slug}. 
 	 * This function below takes the colors we have added to 
-	 * the color pallete of wordpress and generates WordPress compatible class names. 
+	 * the color palette of wordpress and generates WordPress compatible class names. 
 	 * The styles generated are then added to the HTML pages as Internal CSS styles. 
 	 * We do this by using the Wordpress action (wp_head) which lets us run this function when the head is called.
-	 * @var editor-color-pallete
+	 * @var editor-color-palette
 	 */
 	function custom_css()
 	{
 	   $palette = get_theme_support( 'editor-color-palette' );
-	   if( !$palette ) { return; } // If our color pallete has not been define don't run this function.
+	   if( !$palette ) { return; } // If our color palette has not been define don't run this function.
 		   
 	   // format styles
 	   $styles = ":root .has-background { background-color: var(--bgColor); }

--- a/functions.php
+++ b/functions.php
@@ -379,6 +379,6 @@ add_action("cc_theme_before_header" , function() {
 });
 
 // Action to add CC inline color css classes to gutenberg editor
-add_action("enqueue_block_editor_assets" , function() {
+add_action("admin_head" , function() {
     echo "<style>".Site::custom_css()."</style>";
 });

--- a/style.css
+++ b/style.css
@@ -24,9 +24,122 @@ This theme, like WordPress, is licensed under the GPL.
 
 /* override wp group block to fix overflowing */
 .wp-block-group {
-    /* already using border-box sizing */
-    box-sizing: border-box;
-    /* add overflow rule */
-    overflow: hidden;
-    padding: 1.25em 2.375em;
+	/* already using border-box sizing */
+	box-sizing: border-box;
+	/* add overflow rule */
+	overflow: hidden;
+	padding: 1.25em 2.375em;
+}
+
+/* CSS classes for CC colors used in the custom color palette */
+:root .has-background {
+	background-color: var(--bgColor);
+}
+:root .has-text-color {
+	color: var(--textColor);
+}
+:root .has-inline-color {
+	color: var(--textColor);
+}
+.has-tomato-background-color {
+	--bgColor: #c74200;
+}
+.has-tomato-color {
+	--textColor: #c74200;
+}
+.has-dark-slate-gray-background-color {
+	--bgColor: #333333;
+}
+.has-dark-slate-gray-color {
+	--textColor: #333333;
+}
+.has-gold-background-color {
+	--bgColor: #fbd43c;
+}
+.has-gold-color {
+	--textColor: #fbd43c;
+}
+.has-forest-green-background-color {
+	--bgColor: #008000;
+}
+.has-forest-green-color {
+	--textColor: #008000;
+}
+.has-dark-turquoise-background-color {
+	--bgColor: #05b5da;
+}
+.has-dark-turquoise-color {
+	--textColor: #05b5da;
+}
+.has-dark-slate-blue-background-color {
+	--bgColor: #1547a8;
+}
+.has-dark-slate-blue-color {
+	--textColor: #1547a8;
+}
+.has-soft-tomato-background-color {
+	--bgColor: #feede9;
+}
+.has-soft-tomato-color {
+	--textColor: #feede9;
+}
+.has-soft-gold-background-color {
+	--bgColor: #fef6d8;
+}
+.has-soft-gold-color {
+	--textColor: #fef6d8;
+}
+.has-soft-green-background-color {
+	--bgColor: #e0f5e0;
+}
+.has-soft-green-color {
+	--textColor: #e0f5e0;
+}
+.has-soft-turquoise-background-color {
+	--bgColor: #dff6fc;
+}
+.has-soft-turquoise-color {
+	--textColor: #dff6fc;
+}
+.has-soft-blue-background-color {
+	--bgColor: #e3ebfd;
+}
+.has-soft-blue-color {
+	--textColor: #e3ebfd;
+}
+.has-dark-gray-background-color {
+	--bgColor: #767676;
+}
+.has-dark-gray-color {
+	--textColor: #767676;
+}
+.has-gray-background-color {
+	--bgColor: #b0b0b0;
+}
+.has-gray-color {
+	--textColor: #b0b0b0;
+}
+.has-light-gray-background-color {
+	--bgColor: #d8d8d8;
+}
+.has-light-gray-color {
+	--textColor: #d8d8d8;
+}
+.has-lighter-gray-background-color {
+	--bgColor: #f5f5f5;
+}
+.has-lighter-gray-color {
+	--textColor: #f5f5f5;
+}
+.has-white-background-color {
+	--bgColor: #ffffff;
+}
+.has-white-color {
+	--textColor: #ffffff;
+}
+.has-black-background-color {
+	--bgColor: #000000;
+}
+.has-black-color {
+	--textColor: #000000;
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/124 by @MuluhGodson 

## Description
Add support for inline colours to the Gutenberg editor and to the Frontend.
This PR accomplishesthe following:
- [x] Move frontend CSS generators into its own function
- [x] Modify frontend CSS action to use the CSS generating function
- [x] Add action for inline colors to use the CSS  generating function

## Technical details
I moved the code that generated the CSS classes into a function so I can use it for both actions that will enable inline colors for the admin editor and also be able to render these colors in the frontend. 



## Screenshots
#### Frontend render
![image](https://user-images.githubusercontent.com/40151808/140311045-ab8c6d20-1588-42fc-851a-edcf026a7e57.png)

#### Admin editor
![image](https://user-images.githubusercontent.com/40151808/140311137-e027f407-effd-48ab-9caf-dab1030021a4.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
