### PR TITLE
Overriding styles for latest post to match the mockups

### DIFF
--- a/style.css
+++ b/style.css
@@ -188,3 +188,39 @@ span.has-inline-color > strong {
 	overflow: hidden;
 	padding: 1.25em 2.375em;
 }
+
+.wp-block-latest-posts__list > li > a {
+	font-weight: bold;
+	text-decoration: none;
+	color: #000000;
+	font-size: 2.4em;
+	display: inline-block;
+	line-height: 1em;
+}
+
+.wp-block-latest-posts__post-author {
+	display: inline-block;
+	font-weight: bold;
+	color: #c74200;
+	font-size: 1rem;
+}
+
+.wp-block-latest-posts__post-date {
+	display: inline-block;
+	font-weight: bold;
+	font-size: 1rem;
+	margin-left: 0.4rem;
+}
+.wp-block-latest-posts__post-date::before {
+	content: '\2022';
+	font-size: 2rem;
+	color: #B0B0B0;
+	margin-right: 0.4rem;
+	margin-top: 0.5rem;
+	top: 0.1em;
+    position: relative;
+}
+
+.wp-block-latest-posts__featured-image {
+	float: left;
+}

--- a/style.css
+++ b/style.css
@@ -220,7 +220,3 @@ span.has-inline-color > strong {
 	top: 0.1em;
     position: relative;
 }
-
-.wp-block-latest-posts__featured-image {
-	float: left;
-}


### PR DESCRIPTION
## Fixes

Fixes https://github.com/creativecommons/project_creativecommons.org/issues/42 by @brylie 

## Description
Adding CSS styles to override default styling in latest posts so as to make it similar to the design mockups.


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
