### PR TITLE
Change caption colors to inherit from parent

### DIFF
--- a/style.css
+++ b/style.css
@@ -176,7 +176,7 @@ span.has-inline-color > strong {
 	font-weight: normal;
 	font-size: 0.8rem;
 	line-height: 1.1;
-	color: #333333;
+	color: inherit;
 	text-align: center;
 }
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/148 by @brylie 

## Description
This PR changes the color property of captions ensuring that they inherit their color from the parent element where the image/figure is placed. However, there are some things to note, which may be included in the USER TRAINING modules. See the technical details below.

## Technical details
In the screenshot below, the parents are placed in a group with the tomato background colour. However, no text colour has been set for this particular column so any text found in this column will inherit it's colour from the body element.
![image](https://user-images.githubusercontent.com/40151808/142386087-d2a26145-b390-4390-b177-01a404450742.png)

Body Element: 
![image](https://user-images.githubusercontent.com/40151808/142386274-afa5f677-5d0a-4f15-b5fa-fde8a2bb83c2.png)

We can set colours to individual blocks of text and paragraphs but for captions to inherit a colour other than that of the global body element, then the column where the images are placed needs to have a text colour set.

In the screenshot below, I have set a text colour (white) for the column where these images are places.

![image](https://user-images.githubusercontent.com/40151808/142386621-71be17d8-1ce2-40a8-b849-bf69fe5875cd.png)

and the frontend render, the captions inherit the proper colour (white) instead of the color property of the global body element. 
![image](https://user-images.githubusercontent.com/40151808/142386975-76d46a6a-6b8a-484d-830c-0c03ab09faf4.png)


So in conclusion, for the inheritance to work properly, the parent element (group or column) where the image is placed needs to have a text colour set for it, else the captions will inherit the colour property of the next parent element that has a colour property set.
## Screenshots
![image](https://user-images.githubusercontent.com/40151808/142387043-f1fedc0b-a11e-4bf5-9640-537a972e30ef.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
