### PR TITLE
Updating walker conditions so that it fails gracefully

### DIFF
--- a/inc/class-walkers.php
+++ b/inc/class-walkers.php
@@ -14,9 +14,23 @@
  */
 
 class Navwalker extends Walker_Nav_Menu {
+	/** 
+	 * Creates the start element.
+	 * @param string $output Html string containing the output.
+	 * @param int $depth nesting level of the menu.
+	 * @param array $args Other dynamic input.
+	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
 		$output .= "<div class='navbar-dropdown'>";
 	}
+
+	/**
+	 * Creates the menu using an anchor tag. Creates dropdown if the given menu has children.
+	 * @param string $output Html string containing the output.
+	 * @param object $item menu information of a single menu item.
+	 * @param int $depth nesting level of the menu.
+	 * @param array $args Other dynamic input.
+	 */
 	public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
 		$classes      = empty( $item->classes ) ? array() : (array) $item->classes;
 		$classes[]    = 'menu-item-' . $item->ID;
@@ -35,13 +49,29 @@ class Navwalker extends Walker_Nav_Menu {
 			$item->classes[] = 'has_children';
 		}
 	}
+	/**
+	 * Append the end of element tag. If there are more records to process it completes the previous
+	 * anchor tag else it add the final end-div tag
+	 * @param string $output Html string containing the output.
+	 * @param object $item menu information of a single menu item.
+	 * @param int $depth nesting level of the menu.
+	 * @param array $args Other dynamic input.
+	 */
 	public function end_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+		/* Checks if the current item has any child elements */
 		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 		if ( in_array( 'has_children', $classes) ) {
 			$output .= '</div>';
 		}
 		$output .= '</a>';
 	}
+
+	/**
+	 * Adds end of div tag for any given menu
+	 * @param string $output Html string containing the output.
+	 * @param int $depth nesting level of the menu.
+	 * @param array $args Other dynamic input.
+	 */
 	public function end_lvl( &$output, $depth = 0, $args = array() ) {
 		$output .= '</div>';
 	}

--- a/inc/class-walkers.php
+++ b/inc/class-walkers.php
@@ -22,7 +22,7 @@ class Navwalker extends Walker_Nav_Menu {
 		$classes[]    = 'menu-item-' . $item->ID;
 		$class_names  = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
 		$li_classes   = 'navbar-item ' . $item->post_name . ' ' . $class_names;
-		$has_children = $args->walker->has_children;
+		$has_children = empty($args->walker) ? false : $args->walker->has_children;
 		$li_classes  .= $has_children ? ' has-dropdown is-hoverable' : '';
 		if ( $has_children ) {
 			$output .= "<div class='" . $li_classes . "'>";
@@ -36,7 +36,8 @@ class Navwalker extends Walker_Nav_Menu {
 		}
 	}
 	public function end_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
-		if ( in_array( 'has_children', $item->classes ) ) {
+		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
+		if ( in_array( 'has_children', $classes) ) {
 			$output .= '</div>';
 		}
 		$output .= '</a>';


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/104  by @brylie 

## Description
Checking if the `walker object` is defined. If not, `has_children` is set to false. If the main menu is empty walker object will be empty.


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
