### PR TITLE
move vocabulary import to header.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<script src="https://unpkg.com/@creativecommons/vocabulary@2020.11.3/css/vocabulary.css"></script>
 	<title><?php wp_title( '|' ); ?></title>
 	<?php wp_head(); ?>
 </head>

--- a/header.php
+++ b/header.php
@@ -3,7 +3,9 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<script src="https://unpkg.com/@creativecommons/vocabulary@2020.11.3/css/vocabulary.css"></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
+	<link rel="stylesheet" href="https://unpkg.com/@creativecommons/fonts@2020.9.3/css/fonts.css">
+	<link rel="stylesheet" href="https://unpkg.com/@creativecommons/vocabulary@2020.11.3/css/vocabulary.css">
 	<title><?php wp_title( '|' ); ?></title>
 	<?php wp_head(); ?>
 </head>

--- a/style.css
+++ b/style.css
@@ -11,9 +11,6 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 This theme, like WordPress, is licensed under the GPL.
 */
 
-@import url(https://unpkg.com/browse/bulma@0.9.3/);
-@import url(https://unpkg.com/@creativecommons/fonts@2020.9.3/css/fonts.css);
-
 /* CSS classes for CC colors used in the custom color palette */
 :root .has-background {
 	background-color: var(--bgColor);

--- a/style.css
+++ b/style.css
@@ -13,7 +13,6 @@ This theme, like WordPress, is licensed under the GPL.
 
 @import url(https://unpkg.com/browse/bulma@0.9.3/);
 @import url(https://unpkg.com/@creativecommons/fonts@2020.9.3/css/fonts.css);
-@import url(https://unpkg.com/@creativecommons/vocabulary@2020.11.3/css/vocabulary.css);
 
 /* CSS classes for CC colors used in the custom color palette */
 :root .has-background {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/184 by @brylie 

## Description
This PR removes the vocabulary import from the root `style.css` to `header.php` so it's loaded only for the front end.

## Screenshots
Admin panel back to normal (unaffected by vocabulary)
![image](https://user-images.githubusercontent.com/40151808/144573953-59e10fa1-c8b6-4608-8e85-dc5825eeb558.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
