### PR TITLE
Refactoring sidebars from the app

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -62,8 +62,11 @@ $mandatory_sidebars = array(
 	'Page'                  => array(
 		'name' => 'page',
 	),
-	'Page Footer'           => array(
-		'name' => 'page-footer',
+	'Before Footer'           => array(
+		'name' => 'before-footer',
+	),
+	'After Navigation' => array(
+		'name' => 'after-navigation',
 	),
 );
 /**

--- a/header.php
+++ b/header.php
@@ -1,51 +1,66 @@
 <!doctype html>
 <html>
+
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
 	<link rel="stylesheet" href="https://unpkg.com/@creativecommons/fonts@2020.9.3/css/fonts.css">
 	<link rel="stylesheet" href="https://unpkg.com/@creativecommons/vocabulary@2020.11.3/css/vocabulary.css">
-	<title><?php wp_title( '|' ); ?></title>
+	<title><?php wp_title('|'); ?></title>
 	<?php wp_head(); ?>
 </head>
 
 <body <?php body_class(); ?>>
-<?php include 'explore-cc.php'; ?>
-<?php do_action( 'cc_theme_before_header' ); ?>
-<!--BEGIN HEADER-->
-<header class="main-header">
-	<?php do_action( 'cc_theme_before_header_content' ); ?>
-	<div class="container">
-		<nav class="navbar">
-			<div class="navbar-brand">
-			<a href="<?php bloginfo( 'url' ); ?>" class="has-text-black">
-				<?php echo CC_Site::get_current_website_logo(); ?>
-			</a>
-			<a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
-				<span aria-hidden="true"></span>
-				<span aria-hidden="true"></span>
-				<span aria-hidden="true"></span>
-			</a>
+	<?php include 'explore-cc.php'; ?>
+	<?php do_action('cc_theme_before_header'); ?>
+	<!--BEGIN HEADER-->
+	<header class="main-header">
+		<?php do_action('cc_theme_before_header_content'); ?>
+		<div class="container">
+			<nav class="navbar">
+				<div class="navbar-brand">
+					<a href="<?php bloginfo('url'); ?>" class="has-text-black">
+						<?php echo CC_Site::get_current_website_logo(); ?>
+					</a>
+					<a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
+						<span aria-hidden="true"></span>
+						<span aria-hidden="true"></span>
+						<span aria-hidden="true"></span>
+					</a>
+				</div>
+				<?php
+				wp_nav_menu(
+					array(
+						'theme_location'  => 'main-navigation',
+						'depth'           => 2,
+						'container'       => 'div',
+						'container_class' => 'navbar-menu',
+						'items_wrap'      => '<div id="%1$s" class="navbar-end">%3$s</div>',
+						'menu_class'      => 'navbar-menu',
+						'menu_id'         => 'primary-menu',
+						'after'           => '</div>',
+						'walker'          => new Navwalker(),
+					)
+				);
+				?>
+			</nav>
 		</div>
-	<?php
-		wp_nav_menu(
-			array(
-				'theme_location'  => 'main-navigation',
-				'depth'           => 2,
-				'container'       => 'div',
-				'container_class' => 'navbar-menu',
-				'items_wrap'      => '<div id="%1$s" class="navbar-end">%3$s</div>',
-				'menu_class'      => 'navbar-menu',
-				'menu_id'         => 'primary-menu',
-				'after'           => '</div>',
-				'walker'          => new Navwalker(),
-			)
-		);
+		<?php
+		if (function_exists('yoast_breadcrumb')) {
+			yoast_breadcrumb('<p id="breadcrumbs">', '</p>');
+		}
 		?>
-		</nav>
-	</div>
-	<?php do_action( 'cc_theme_after_header_content' ); ?>
-</header>
-<!--END HEADER-->
-<?php do_action( 'cc_theme_after_header' ); ?>
+		<?php if (is_active_sidebar('after-navigation')) : ?>
+			<div class="container notification-container push-up">
+				<div class="columns is-centered is-gapless">
+					<div class="column is-10">
+						<?php dynamic_sidebar('after-navigation'); ?>
+					</div>
+				</div>
+			</div>
+		<?php endif; ?>
+		<?php do_action('cc_theme_after_header_content'); ?>
+	</header>
+	<!--END HEADER-->
+	<?php do_action('cc_theme_after_header'); ?>

--- a/inc/partials/entry/page-footer.php
+++ b/inc/partials/entry/page-footer.php
@@ -1,7 +1,7 @@
-<?php if ( is_active_sidebar( 'page-footer' ) ) : ?>
+<?php if ( is_active_sidebar( 'before-footer' ) ) : ?>
 <footer class="entry-footer padding-vertical-bigger">
 	<div class="container">
-		<?php dynamic_sidebar( 'page-footer' ); ?>
+		<?php dynamic_sidebar( 'before-footer' ); ?>
 	</div>
 </footer>
 <?php endif; ?>


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/project_creativecommons.org/issues/166  by @brylie 

## Description
Removing all unused sidebars and only keeping the `Page` sidebar. Also, added before-footer and after-navigation sidebars.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

