### PR TITLE
Adding theme styles to enable full support for align-wide

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,8 +7,10 @@
  */
 require get_theme_file_path( 'inc/theme-customizer.php' );
 
-/* Allow full-width Gutenberg widget alignment */
-add_theme_support( 'align-wide' );
+function my_theme_setup() {
+	/* Allow full-width Gutenberg widget alignment */
+	add_theme_support( 'align-wide' );
+}
 
 /* Theme Constants (to speed up some common things) ------*/
 define( 'HOME_URI', get_bloginfo( 'url' ) );
@@ -341,3 +343,4 @@ $cc_colors = array(
 
 // This line below adds the colors defined above into the color pallete of WordPress
 add_theme_support( 'editor-color-palette', $cc_colors);
+add_action( 'after_setup_theme', 'my_theme_setup' );

--- a/style.css
+++ b/style.css
@@ -261,3 +261,24 @@ span.has-inline-color > strong {
 .color-black {
 	color: #000000;
 }
+@media (min-width: 750px) {
+
+	.alignfull {
+		max-width: 1000%;
+		margin-right: calc(50% - 50vw);
+		margin-left: calc(50% - 50vw);
+		width: auto;
+	}
+
+	.alignwide {
+		max-width: 1000%;
+		margin-right: calc(25% - 25vw);
+		margin-left: calc(25% - 25vw);
+		width: auto;
+	}
+
+	.wp-block-group__inner-container {
+		max-width: 85.7143rem;
+                margin: auto;
+	}
+}


### PR DESCRIPTION
…press feature

## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #https://github.com/creativecommons/project_creativecommons.org/issues/205 by @shailee-m 


CC: @brylie , @MuluhGodson 

## Description
Alignwide requires separate style support from the child theme. From some trial and error and reading various support forums threads, I have come up with this CSS block.


## Checklist
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.